### PR TITLE
Add per pixel adjustment via arrow keys

### DIFF
--- a/LibEditMode.lua
+++ b/LibEditMode.lua
@@ -1,4 +1,4 @@
-local MINOR = 10
+local MINOR = 9
 local lib = LibStub:NewLibrary('LibEditMode', MINOR)
 if not lib then
 	-- this or a newer version is already loaded
@@ -107,6 +107,15 @@ local function normalizePosition(frame)
 	return point, x / scale, y / scale
 end
 
+local function updateParentPosition(parent, xDelta, yDelta)
+	local point, x, y = normalizePosition(parent)
+	x, y = x + (xDelta or 0), y + (yDelta or 0)
+	parent:ClearAllPoints()
+	parent:SetPoint(point, x, y)
+
+	internal:TriggerCallback(parent, point, x, y)
+end
+
 local function onDragStop(self)
 	local parent = self.parent
 	parent:StopMovingOrSizing()
@@ -114,11 +123,7 @@ local function onDragStop(self)
 	-- TODO: snap position to grid
 	-- FrameXML/EditModeUtil.lua
 
-	local point, x, y = normalizePosition(parent)
-	parent:ClearAllPoints()
-	parent:SetPoint(point, x, y)
-
-	internal:TriggerCallback(parent, point, x, y)
+	updateParentPosition(parent)
 
 	if self.isSelected then
 		internal.dialog:Update(self)
@@ -330,6 +335,14 @@ function internal:GetFrameButtons(frame)
 		return lib.frameButtons[frame], #lib.frameButtons[frame]
 	else
 		return nil, 0
+	end
+end
+
+function internal:MoveParent(selection, x, y)
+	updateParentPosition(selection.parent, x, y)
+
+	if selection.isSelected then
+		internal.dialog:Update(selection)
 	end
 end
 

--- a/widgets/dialog.lua
+++ b/widgets/dialog.lua
@@ -115,6 +115,9 @@ function dialogMixin:ResetPosition()
 	internal:TriggerCallback(parent, pos.point, pos.x, pos.y)
 end
 
+local BIG_STEP = 10
+local SMALL_STEP = 1
+
 function internal:CreateDialog()
 	local dialog = Mixin(CreateFrame('Frame', nil, UIParent, 'ResizeLayoutFrame'), dialogMixin)
 	dialog:SetSize(300, 350)
@@ -135,6 +138,25 @@ function internal:CreateDialog()
 	end)
 	dialog:SetScript('OnDragStop', function()
 		dialog:StopMovingOrSizing()
+	end)
+	dialog:SetScript('OnKeyDown', function(_, key)
+		if dialog.selection then
+			dialog:SetPropagateKeyboardInput(false)
+
+			if key == 'LEFT' then
+				internal:MoveParent(dialog.selection, IsShiftKeyDown() and -BIG_STEP or -SMALL_STEP)
+			elseif key == 'RIGHT' then
+				internal:MoveParent(dialog.selection, IsShiftKeyDown() and BIG_STEP or SMALL_STEP)
+			elseif key == 'UP' then
+				internal:MoveParent(dialog.selection, 0, IsShiftKeyDown() and BIG_STEP or SMALL_STEP)
+			elseif key == 'DOWN' then
+				internal:MoveParent(dialog.selection, 0, IsShiftKeyDown() and -BIG_STEP or -SMALL_STEP)
+			else
+				dialog:SetPropagateKeyboardInput(true)
+			end
+		else
+			dialog:SetPropagateKeyboardInput(true)
+		end
 	end)
 
 	local dialogTitle = dialog:CreateFontString(nil, nil, 'GameFontHighlightLarge')


### PR DESCRIPTION
It works, but I'm not sure about the names and whatnot, like

```lua
updateParentPosition(parent)

if self.isSelected then
	internal.dialog:Update(self)
end
```
and
```lua
updateParentPosition(selection.parent, x, y)

if selection.isSelected then
   internal.dialog:Update(selection)
end
```
being basically identical, but you'll figure it out 😅