### PR TITLE
LibEditMode Combat Taint for secure frames

### DIFF
--- a/LibEditMode.lua
+++ b/LibEditMode.lua
@@ -116,13 +116,13 @@ local function normalizePosition(frame)
 end
 
 local function onDragStop(self)
+	if InCombatLockdown and InCombatLockdown() then return end
 	local parent = self.parent
 	if parent then parent:StopMovingOrSizing() end
 	if self.combatDragActive then
 		self:UnregisterEvent('PLAYER_REGEN_DISABLED')
 		self.combatDragActive = nil
 	end
-	if InCombatLockdown and InCombatLockdown() then return end
 	if not (parent and parent.IsMovable and parent:IsMovable()) then return end
 
 	-- TODO: snap position to grid


### PR DESCRIPTION
  We had to make Edit Mode safe against combat lockdown. If you drag a secure frame (action bars, custom anchors, etc.) and combat fires mid-move,
  Blizzard immediately blocks StartMoving/StopMovingOrSizing/ClearAllPoints. Without guards, LibEditMode taints and leaves the selection stuck
  in “dragging”.

  Key changes:

  1. Selections during combat resetSelection now hides the highlight whenever combat is active. That keeps the selection frame from touching protected regions while the player is fighting.
  2. Drag handlers onDragStart and onDragStop check both InCombatLockdown() and parent:IsMovable(). We also keep the PLAYER_REGEN_DISABLED hook, but now it is used solely to force a pending drag to end the moment combat begins: the selection stops moving, unregisters the event, and hides itself. This prevents the “drag never stops” issue that previously tainted protected anchors.
  3. Deferred positioning In our consumer helper we defer any layout/visibility updates on protected frames while combat is running, and flush them on PLAYER_REGEN_ENABLED. That keeps Edit Mode responsive, but all secure calls still happen outside lockdown.