### PR TITLE
Add divider widget

### DIFF
--- a/LibEditMode.lua
+++ b/LibEditMode.lua
@@ -427,11 +427,12 @@ Table containing the following entries:
 | isRadio | turns the dropdown entry into a Radio button, otherwise a Checkbox | boolean | no       |
 
 ## SettingType
-Convenient shorthand for `Enum.EditModeSettingDisplayType`.
+Table containing available setting types.
 
 One of:
 - `Dropdown`
 - `Checkbox`
 - `Slider`
+- `Divider`
 --]]
 lib.SettingType = CopyTable(Enum.EditModeSettingDisplayType)

--- a/embed.xml
+++ b/embed.xml
@@ -2,6 +2,7 @@
 	<Script file='LibEditMode.lua'/>
 	<Script file='pools.lua'/>
 	<Script file='widgets\dialog.lua'/>
+	<Script file='widgets\divider.lua'/>
 	<Script file='widgets\dropdown.lua'/>
 	<Script file='widgets\slider.lua'/>
 	<Script file='widgets\checkbox.lua'/>

--- a/widgets/dialog.lua
+++ b/widgets/dialog.lua
@@ -94,7 +94,9 @@ function dialogMixin:ResetSettings()
 	local settings, num = internal:GetFrameSettings(self.selection.parent)
 	if num > 0 then
 		for _, data in next, settings do
-			data.set(lib.activeLayoutName, data.default)
+			if data.set then
+				data.set(lib.activeLayoutName, data.default)
+			end
 		end
 
 		self:Update(self.selection)

--- a/widgets/divider.lua
+++ b/widgets/divider.lua
@@ -1,0 +1,32 @@
+local MINOR = 10
+local lib, minor = LibStub('LibEditMode')
+if minor > MINOR then
+	return
+end
+
+lib.SettingType.Divider = 'divider'
+
+local dividerMixin = {}
+function dividerMixin:Setup(data)
+	self.setting = data
+	self.Label:SetText(data.name)
+end
+
+lib.internal:CreatePool(lib.SettingType.Divider, function()
+	local frame = Mixin(CreateFrame('Frame', nil, UIParent), dividerMixin)
+	frame:SetSize(330, 16)
+
+	local texture = frame:CreateTexture(nil, 'ARTWORK')
+	texture:SetAllPoints()
+	texture:SetTexture([[Interface\FriendsFrame\UI-FriendsFrame-OnlineDivider]])
+
+	local label = frame:CreateFontString(nil, nil, 'GameFontHighlightLarge')
+	label:SetAllPoints()
+	frame.Label = label
+
+	return frame
+end, function(_, frame)
+	frame:Hide()
+	frame.Label:SetText()
+	frame.layoutIndex = nil
+end)


### PR DESCRIPTION
As the title suggests, it adds label-able dividers as a viable widget for settings.