### PR TITLE
Manually fetch layout info

### DIFF
--- a/LibEditMode.lua
+++ b/LibEditMode.lua
@@ -234,6 +234,9 @@ local function hookManager()
 		end
 	end)
 
+	-- fetch layout info in case EDIT_MODE_LAYOUTS_UPDATED already fired
+	onEditModeChanged(nil, C_EditMode.GetLayouts())
+
 	isManagerHooked = true
 end
 


### PR DESCRIPTION
If for whatever reason settings are registered after PL, maybe the code is LoD, the lib will fail to fetch the active layout name.