### PR TITLE
Split entry's name and value

### DIFF
--- a/widgets/dropdown.lua
+++ b/widgets/dropdown.lua
@@ -33,13 +33,13 @@ function dropdownMixin:Setup(data)
 					rootDescription:CreateRadio(value.text, get, set, {
 						get = data.get,
 						set = data.set,
-						value = value.text,
+						value = value.value or value.text,
 					})
 				else
 					rootDescription:CreateCheckbox(value.text, get, set, {
 						get = data.get,
 						set = data.set,
-						value = value.text
+						value = value.value or value.text,
 					})
 				end
 			end


### PR DESCRIPTION
Currently, you have to use custom generators all the time if your value's name and actual value don't match. 
```lua
{
	isRadio = true,
	text = "Square",
	value = 1,
},
{
	isRadio = true,
	text = "Round",
	value = 2,
},
```
will result in
<img width="258" height="69" alt="image" src="https://github.com/user-attachments/assets/5770395b-4215-4575-84ca-ae73d983e498" />
