### PR TITLE
Try to run layout callback on registration

### DIFF
--- a/LibEditMode.lua
+++ b/LibEditMode.lua
@@ -323,12 +323,6 @@ function lib:AddFrame(frame, callback, default, name)
 			hookManager()
 		end
 	end
-
-	-- ugly hack
-	for _, cb in next, lib.anonCallbacksLayout do
-		local activeLayout = lib:GetActiveLayout()
-		securecallfunction(cb, layoutNames[activeLayout], activeLayout)
-	end
 end
 
 --[[ LibEditMode:AddFrameSettings(_frame, settings_) ![](https://img.shields.io/badge/function-blue)
@@ -464,6 +458,11 @@ function lib:RegisterCallback(event, callback)
 		table.insert(lib.anonCallbacksExit, callback)
 	elseif event == 'layout' then
 		table.insert(lib.anonCallbacksLayout, callback)
+
+		-- if there's none, then onEditModeChanged will take care of it
+		if lib.activeLayout then
+			securecallfunction(callback, layoutNames[lib.activeLayout], lib.activeLayout)
+		end
 	elseif event == 'create' then
 		table.insert(lib.anonCallbacksCreate, callback)
 	elseif event == 'rename' then

--- a/tests/button.lua
+++ b/tests/button.lua
@@ -22,6 +22,8 @@ local defaultPosition = {
 }
 
 local LEM = LibStub('LibEditMode')
+LEM:AddFrame(button, onPositionChanged, defaultPosition)
+
 LEM:RegisterCallback('layout', function(layoutName)
 	if not ButtonDB then
 		ButtonDB = {}
@@ -33,8 +35,6 @@ LEM:RegisterCallback('layout', function(layoutName)
 	button:ClearAllPoints()
 	button:SetPoint(ButtonDB[layoutName].point, ButtonDB[layoutName].x, ButtonDB[layoutName].y)
 end)
-
-LEM:AddFrame(button, onPositionChanged, defaultPosition)
 
 LEM:AddFrameSettings(button, {
 	{


### PR DESCRIPTION
A less ugly "hack". Instead of triggering all layout callbacks whenever a new frame is being registered, just run the callback after it's added to the system. It'll also make it work with blizz systems and not just custom frames.